### PR TITLE
Bumping AWS SDK versions up to last 1.10.x release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
 
   :dependencies [[joda-time "2.9.3"]
                  [amazonica "0.3.53" :exclusions [com.amazonaws/aws-java-sdk]]
-                 [com.amazonaws/aws-java-sdk-core "1.10.49"]
-                 [com.amazonaws/aws-java-sdk-s3 "1.10.49"]
+                 [com.amazonaws/aws-java-sdk-core "1.10.77"]
+                 [com.amazonaws/aws-java-sdk-s3 "1.10.77"]
                  [org.springframework.build/aws-maven "5.0.0.RELEASE"
                   :exclusions [joda-time]]
                  [funcool/cuerdas "0.7.2"]


### PR DESCRIPTION
Not sure if 1.11.x releases could cause problems, so just bumping to latest 1.10 versions while I'm here.
