### PR TITLE
use fixed fork of aws-maven project

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [amazonica "0.3.53" :exclusions [com.amazonaws/aws-java-sdk]]
                  [com.amazonaws/aws-java-sdk-core "1.10.49"]
                  [com.amazonaws/aws-java-sdk-s3 "1.10.49"]
-                 [org.springframework.build/aws-maven "5.0.0.RELEASE"
+                 [org.clojars.brabster/aws-maven-fix "0.1.0"
                   :exclusions [joda-time]]
                  [funcool/cuerdas "0.7.2"]
                  [me.raynes/fs "1.4.6"]


### PR DESCRIPTION
fixes #3

I deployed https://github.com/ImmobilienScout24/aws-maven to
clojars. This PR contains three commits that fix the
CredentialsProviderChain so that the ProfileCredentialsProvider is used
as the last override to hard-coded credentials.

I've tested the :repository aspect with credentials in .aws/credentials
and it works. I'll be testing that :deploy :library also works shortly.

Hopefully one day the canonical aws-maven repo will get fixed and we can
switch over to that.
