### PR TITLE
Update amazonica

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :min-lein-version "2.0.0"
 
   :dependencies [[joda-time "2.9.3"]
-                 [amazonica "0.3.53" :exclusions [com.amazonaws/aws-java-sdk]]
+                 [amazonica "0.3.74"]
                  [com.amazonaws/aws-java-sdk-core "1.10.49"]
                  [com.amazonaws/aws-java-sdk-s3 "1.10.49"]
                  [org.springframework.build/aws-maven "5.0.0.RELEASE"


### PR DESCRIPTION
This fixes a problem whereby AWS STS credentials are not usable, e.g. as
issued by aws-vault. The underlying problem seems to in earlier versions
of the aws-java-sdk.

There being no tests to run, I don't know if this breaks anything, but
the limited integrations I've used seem to work fine.
